### PR TITLE
Public access to structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stardict"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Rust implement stardict"
 authors = ["zang.loo"]

--- a/src/idx.rs
+++ b/src/idx.rs
@@ -37,8 +37,8 @@ impl IdxEntry {
 
 #[derive(Debug)]
 pub struct Idx {
-	pub(super) items: HashMap<String, IdxEntry>,
-	pub(super) syn: Option<HashMap<String, HashSet<String>>>,
+	pub items: HashMap<String, IdxEntry>,
+	pub syn: Option<HashMap<String, HashSet<String>>>,
 }
 
 #[allow(unused)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod error;
 mod stardict;
-mod idx;
-mod ifo;
-mod dict;
+pub mod idx;
+pub mod ifo;
+pub mod dict;
 mod dictzip;
 #[cfg(feature = "sled")]
 mod stardict_sled;

--- a/src/stardict.rs
+++ b/src/stardict.rs
@@ -7,11 +7,10 @@ use std::path::PathBuf;
 use crate::{StarDict, WordDefinition};
 
 pub struct StarDictStd {
-	path: PathBuf,
-
+	pub path: PathBuf,
 	pub ifo: Ifo,
-	idx: Idx,
-	dict: Dict,
+	pub idx: Idx,
+	pub dict: Dict,
 }
 
 impl StarDictStd {


### PR DESCRIPTION
Thanks for the neat parser! It's cool that it pulls in only a few simple dependencies as well.

This PR makes some structs and properties public access so that after the stardict file is parsed into Rust structs, we can process and parse them further.